### PR TITLE
Transition to new ArrayList API

### DIFF
--- a/src/compile.zig
+++ b/src/compile.zig
@@ -317,7 +317,7 @@ pub const Compiler = struct {
             },
             Expr.Concat => |subexprs| {
                 // Compile each item in the sub-expression
-                var f = subexprs.toSliceConst()[0];
+                var f = subexprs.items[0];
 
                 // First patch
                 const p = try c.compileInternal(f);
@@ -325,7 +325,7 @@ pub const Compiler = struct {
                 const entry = p.entry;
 
                 // tie together patches from concat arguments
-                for (subexprs.toSliceConst()[1..]) |e| {
+                for (subexprs.items[1..]) |e| {
                     const ep = try c.compileInternal(e);
                     // fill the previous patch hole to the current entry
                     c.fill(hole, ep.entry);
@@ -514,7 +514,7 @@ pub const Compiler = struct {
             Hole.None => {},
             Hole.One => |pc| c.insts.items[pc].fill(goto1),
             Hole.Many => |holes| {
-                for (holes.toSliceConst()) |hole1|
+                for (holes.items) |hole1|
                     c.fill(hole1, goto1);
             },
         }

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -58,7 +58,7 @@ fn dumpExprIndent(e: Expr, indent: usize) void {
         },
         Expr.ByteClass => |class| {
             debug.warn("{}(", .{ @tagName(e) });
-            for (class.ranges.toSliceConst()) |r| {
+            for (class.ranges.items) |r| {
                 debug.warn("[", .{});
                 printCharEscaped(r.min);
                 debug.warn("-", .{});
@@ -70,12 +70,12 @@ fn dumpExprIndent(e: Expr, indent: usize) void {
         // TODO: Can we get better type unification on enum variants with the same type?
         Expr.Concat => |subexprs| {
             debug.warn("{}\n", .{ @tagName(e) });
-            for (subexprs.toSliceConst()) |s|
+            for (subexprs.items) |s|
                 dumpExprIndent(s.*, indent + 1);
         },
         Expr.Alternate => |subexprs| {
             debug.warn("{}\n", .{ @tagName(e) });
-            for (subexprs.toSliceConst()) |s|
+            for (subexprs.items) |s|
                 dumpExprIndent(s.*, indent + 1);
         },
         // NOTE: Shouldn't occur ever in returned output.
@@ -97,7 +97,7 @@ pub fn dumpInstruction(s: Instruction) void {
         },
         InstructionData.ByteClass => |class| {
             debug.warn("range({}) ", .{ s.out });
-            for (class.ranges.toSliceConst()) |r|
+            for (class.ranges.items) |r|
                 debug.warn("[{}-{}]", .{ r.min, r.max });
             debug.warn("\n", .{});
         },

--- a/src/parse_test.zig
+++ b/src/parse_test.zig
@@ -111,7 +111,7 @@ fn reprIndent(out: *StaticOutStream, e: *Expr, indent: usize) anyerror!void {
         },
         Expr.ByteClass => |class| {
             try out.outStream().print("bset(", .{});
-            for (class.ranges.toSliceConst()) |r| {
+            for (class.ranges.items) |r| {
                 try out.outStream().print("[", .{});
                 try out.printCharEscaped(r.min);
                 try out.outStream().print("-", .{});
@@ -123,12 +123,12 @@ fn reprIndent(out: *StaticOutStream, e: *Expr, indent: usize) anyerror!void {
         // TODO: Can we get better type unification on enum variants with the same type?
         Expr.Concat => |subexprs| {
             try out.outStream().print("cat\n", .{});
-            for (subexprs.toSliceConst()) |s|
+            for (subexprs.items) |s|
                 try reprIndent(out, s, indent + 1);
         },
         Expr.Alternate => |subexprs| {
             try out.outStream().print("alt\n", .{});
-            for (subexprs.toSliceConst()) |s|
+            for (subexprs.items) |s|
                 try reprIndent(out, s, indent + 1);
         },
         // NOTE: Shouldn't occur ever in returned output.

--- a/src/vm_test.zig
+++ b/src/vm_test.zig
@@ -55,7 +55,7 @@ fn check(re_input: []const u8, to_match: []const u8, expected: bool) void {
     var input2 = InputBytes.init(to_match).input;
     const backtrack_result = backtrack.exec(re.compiled, re.compiled.find_start, &input2, &backtrack_slots) catch unreachable;
 
-    const slots_equal = nullableEql(usize, pike_slots.toSliceConst(), backtrack_slots.toSliceConst());
+    const slots_equal = nullableEql(usize, pike_slots.items, backtrack_slots.items);
 
     // Note: slot entries are invalid on non-match
     if (pike_result != backtrack_result or (expected == true and !slots_equal)) {
@@ -76,7 +76,7 @@ fn check(re_input: []const u8, to_match: []const u8, expected: bool) void {
             \\pikevm
             \\
         , .{});
-        for (pike_slots.toSliceConst()) |entry| {
+        for (pike_slots.items) |entry| {
             debug.warn("{} ", .{ entry });
         }
         debug.warn("\n", .{});
@@ -87,7 +87,7 @@ fn check(re_input: []const u8, to_match: []const u8, expected: bool) void {
             \\backtrack
             \\
         , .{});
-        for (backtrack_slots.toSliceConst()) |entry| {
+        for (backtrack_slots.items) |entry| {
             debug.warn("{} ", .{ entry });
         }
         debug.warn("\n", .{});


### PR DESCRIPTION
The new ArrayList API of zig 0.6.0 uses the `.items` field directly instead of `.toSliceConst()`.