### PR TITLE
fix alternate compile by initialising hole

### DIFF
--- a/src/compile.zig
+++ b/src/compile.zig
@@ -377,6 +377,7 @@ pub const Compiler = struct {
                 // TODO: Doees this need to be dynamically allocated?
                 var last_hole = try c.allocator.create(Hole);
                 defer c.allocator.destroy(last_hole);
+                last_hole.* = .None;
 
                 // This compiles one branch of the split at a time.
                 for (subexprs.items[0 .. subexprs.items.len - 1]) |subexpr| {


### PR DESCRIPTION
We need to initialize this; missed during 2444081bbb42f55f2ca55e1961fe88ae1a0a4125.