### PR TITLE
Fixed min concat lower bound

### DIFF
--- a/src/compile.zig
+++ b/src/compile.zig
@@ -272,13 +272,12 @@ pub const Compiler = struct {
                 // Case 4: {m,}
                 else if (repeat.max == null) {
                     // e{2,} => eee*
-
                     // fixed min concatenation
                     const p = try c.compileInternal(repeat.subexpr);
                     var hole = p.hole;
                     const entry = p.entry;
 
-                    var i: usize = 0;
+                    var i: usize = 1;
                     while (i < repeat.min) : (i += 1) {
                         const ep = try c.compileInternal(repeat.subexpr);
                         c.fill(hole, ep.entry);

--- a/src/vm_test.zig
+++ b/src/vm_test.zig
@@ -186,4 +186,5 @@ test "pikevm == backtrackvm" {
     check("[^\\w][^-1-4]", "!.", true);
     check("[^\\w][^-1-4]", " x", true);
     check("[^\\w][^-1-4]", "$b", true);
+    check("a{3,}", "aaa", true);
 }


### PR DESCRIPTION
`a{3,}` was being compiled as:

```
L0: save(1), 0
L1: char(2) 'a'
L2: char(3) 'a'
L3: char(4) 'a'
L4: char(5) 'a'
L5: split(6) 8
L6: char(7) 'a'
L7: jump(5)
L8: save(9), 1
L9: match
L10: split(0) 11
L11: any(10)
```

There's one too many `a`s.