### PR TITLE
Build with Zig 0.11 and Zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,12 +1,20 @@
-const Builder = @import("std").build.Builder;
+const std = @import("std");
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("regex", .{
-        .source_file = .{ .path = "src/regex.zig" },
-    });
+    if (@hasDecl(std.Build, "CreateModuleOptions")) {
+        // Zig 0.11
+        _ = b.addModule("regex", .{
+            .source_file = .{ .path = "src/regex.zig" },
+        });
+    } else {
+        // Zig 0.12-dev.2159
+        _ = b.addModule("regex", .{
+            .root_source_file = .{ .path = "src/regex.zig" },
+        });
+    }
 
     // library tests
     const library_tests = b.addTest(.{


### PR DESCRIPTION
Changes build.zig to build with both Zig 0.11 and the current master
(which includes breaking changes to the build system).

Verified locally with `zigup`:

```
❯ zigup run 0.11.0 build test --summary all
Build Summary: 3/3 steps succeeded
test cached
└─ run test cached
   └─ zig test Debug native cached 19ms MaxRSS:28M

❯ zigup run master build test --summary all
Build Summary: 3/3 steps succeeded
test cached
└─ run test cached
   └─ zig test Debug native cached 14ms MaxRSS:22M
```

This can be updated as needed until the changes are finalized for Zig 0.12.
