### PR TITLE
Update zig 0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0  # most recent stable
+          version: 0.14.0  # most recent stable
 
       - name: Check formatting
         run: zig fmt --check .
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        zig-version: ['0.11.0', '0.12.0']
+        zig-version: ['0.14.0']
         os: [ubuntu-latest]
         allow-fail: [false]
         include:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,13 @@
 .{
-    .name = "regex",
+    .name = .regex,
     .version = "0.1.2",
-    .minimum_zig_version = "0.11.0",
-    .paths = .{""},
+    .minimum_zig_version = "0.14.0",
+    .paths = .{
+        "src",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md"
+    },
+    .fingerprint = 0x4204f8cae7b7106b,
 }

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -303,7 +303,7 @@ pub const Parser = struct {
             return error.StackUnderflow;
         }
 
-        return p.stack.pop();
+        return p.stack.pop().?;
     }
 
     fn popByteClass(p: *Parser) !*Expr {
@@ -415,7 +415,7 @@ pub const Parser = struct {
                             return error.UnopenedParentheses;
                         }
 
-                        const e = p.stack.pop();
+                        const e = p.stack.pop().?;
                         switch (e.*) {
                             // Existing alternation
                             .Alternate => {
@@ -436,7 +436,7 @@ pub const Parser = struct {
                                 }
 
                                 // pop the left parentheses that must now exist
-                                debug.assert(p.stack.pop().* == Expr.PseudoLeftParen);
+                                debug.assert(p.stack.pop().?.* == Expr.PseudoLeftParen);
 
                                 const r = try p.createExpr();
                                 r.* = Expr{ .Capture = e };
@@ -502,7 +502,7 @@ pub const Parser = struct {
                             break;
                         }
 
-                        const e = p.stack.pop();
+                        const e = p.stack.pop().?;
                         switch (e.*) {
                             // Existing alternation, combine
                             .Alternate => {
@@ -577,7 +577,7 @@ pub const Parser = struct {
 
         // special case single item to avoid top-level concat for simple.
         if (p.stack.items.len == 1) {
-            return p.stack.pop();
+            return p.stack.pop().?;
         }
 
         // finish a concatenation result
@@ -608,7 +608,7 @@ pub const Parser = struct {
             }
 
             // pop an item, check if it is an alternate and not a pseudo left paren
-            const e = p.stack.pop();
+            const e = p.stack.pop().?;
             switch (e.*) {
                 .PseudoLeftParen => {
                     return error.UnclosedParentheses;
@@ -629,7 +629,7 @@ pub const Parser = struct {
 
                     // if stack is not empty, this is an error
                     if (p.stack.items.len != 0) {
-                        switch (p.stack.pop().*) {
+                        switch (p.stack.pop().?.*) {
                             .PseudoLeftParen => return error.UnclosedParentheses,
                             else => unreachable,
                         }

--- a/src/vm_backtrack.zig
+++ b/src/vm_backtrack.zig
@@ -78,7 +78,7 @@ pub const VmBacktrack = struct {
         const t = Job{ .Thread = Thread{ .ip = prog_start, .input = input.clone() } };
         try state.jobs.append(t);
 
-        while (state.jobs.popOrNull()) |job| {
+        while (state.jobs.pop()) |job| {
             switch (job) {
                 Job.Thread => |thread| {
                     if (try step(&state, &thread)) {

--- a/src/vm_pike.zig
+++ b/src/vm_pike.zig
@@ -85,7 +85,7 @@ pub const VmPike = struct {
         var matched: ?[]?usize = null;
 
         while (!input.isConsumed()) : (input.advance()) {
-            while (clist.popOrNull()) |thread| {
+            while (clist.pop()) |thread| {
                 const inst = prog.insts[thread.pc];
                 const at = input.current();
 


### PR DESCRIPTION
I fixed the minor incompatibilities this lib had with 0.14.0 and up.
Mainly 2 things had to be fixed.

- the "pop()" method now returns an optional value and that needed to be handeled, and the "popOrNull()" method stopped existing.
- I also fixed the build.zig.zon file since it changed the .name to be an emum constant.

I also changed the ci.yml to only use 0.14.0 and master although that remains untested until I submit this pull request.

